### PR TITLE
Fix: Add HttpClient dependency injection for AI services

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -14,6 +14,8 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 
 builder.Services.AddControllers();
 
+builder.Services.AddHttpClient();
+
 builder.Services.AddScoped<OpenAIService>();
 builder.Services.AddScoped<AIRecommendationService>();
 


### PR DESCRIPTION
- Register HttpClient in DI container to resolve OpenAI service dependencies
- Fixes backend startup failure with 'Unable to resolve service for type System.Net.Http.HttpClient'
- Required for OpenAIService and AIRecommendationService to function properly