### PR TITLE
Fix Entity Framework foreign key conflicts

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -145,11 +145,15 @@ namespace irevlogix_backend.Data
                 entity.HasOne(e => e.OriginatorClient)
                     .WithMany()
                     .HasForeignKey(e => e.OriginatorClientId)
-                    .OnDelete(DeleteBehavior.SetNull);
+                    .OnDelete(DeleteBehavior.SetNull)
+                    .IsRequired(false);
                 entity.HasOne(e => e.ClientContact)
                     .WithMany()
                     .HasForeignKey(e => e.ClientContactId)
-                    .OnDelete(DeleteBehavior.SetNull);
+                    .OnDelete(DeleteBehavior.SetNull)
+                    .IsRequired(false);
+                entity.Property(e => e.OriginatorClientId).IsRequired(false);
+                entity.Property(e => e.ClientContactId).IsRequired(false);
             });
 
             modelBuilder.Entity<ShipmentItem>(entity =>
@@ -196,7 +200,9 @@ namespace irevlogix_backend.Data
                 entity.HasOne(e => e.MaterialType)
                     .WithMany()
                     .HasForeignKey(e => e.MaterialTypeId)
-                    .OnDelete(DeleteBehavior.SetNull);
+                    .OnDelete(DeleteBehavior.SetNull)
+                    .IsRequired(false);
+                entity.Property(e => e.MaterialTypeId).IsRequired(false);
             });
 
             modelBuilder.Entity<Asset>(entity =>


### PR DESCRIPTION
- Explicitly configure nullable foreign key relationships for ProcessedMaterial.MaterialTypeId and Shipment.ClientContactId/OriginatorClientId
- Add IsRequired(false) to prevent EF from creating shadow properties MaterialTypeId1 and ClientContactId1
- Resolve 'Exited with status 139' deployment errors caused by EF configuration conflicts