### PR TITLE
fix: make SortOrder nullable in AssetTrackingStatus to handle null da…

### DIFF
--- a/Models/AssetTrackingStatus.cs
+++ b/Models/AssetTrackingStatus.cs
@@ -13,7 +13,7 @@ namespace irevlogix_backend.Models
         
         public bool IsActive { get; set; } = true;
         
-        public int SortOrder { get; set; } = 0;
+        public int? SortOrder { get; set; } = 0;
         
         [MaxLength(20)]
         public string? ColorCode { get; set; }


### PR DESCRIPTION
…tabase values

- Change SortOrder from int to int? in AssetTrackingStatus model
- Fixes InvalidCastException when database contains null values in SortOrder column
- Maintains backward compatibility with existing controller logic
- Resolves 'Column SortOrder is null' error in AssetTrackingController GetStatuses endpoint